### PR TITLE
A few small testing fixes...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 env:
   global:
-    - CONDA_DEPS="pip flake8 numpy scipy numba joblib dask nose" PIP_DEPS="pytest coveralls pytest-cov"
+    - CONDA_DEPS="pip flake8 numpy scipy numba joblib dask" PIP_DEPS="pytest coveralls pytest-cov"
 
 matrix:
   include:
@@ -39,7 +39,7 @@ script:
 
 - mkdir for_test
 - cd for_test
-- py.test --pyargs pulse2percept --cov-report term-missing --cov=pulse2percept
+- py.test --pyargs pulse2percept --cov-report term-missing --cov=pulse2percept --doctest-modules
 
 after_success:
 - coveralls

--- a/pulse2percept/effectivecurrent2brightness.py
+++ b/pulse2percept/effectivecurrent2brightness.py
@@ -280,7 +280,7 @@ def pulse2percept(stim, implant, tm=None, retina=None,
     Stimulate a single-electrode array:
     >>> implant = e2cm.ElectrodeArray('subretinal', 0, 0, 0, 0)
     >>> stim = e2cm.Psycho2Pulsetrain(tsample=5e-6, freq=50, amp=20)
-    >>> ec2b.pulse2percept(stim, implant)
+    >>> pulse2percept(stim, implant)
 
     Stimulate a single electrode ('C3') of an Argus I array centered on the
     fovea:

--- a/pulse2percept/electrode2currentmap.py
+++ b/pulse2percept/electrode2currentmap.py
@@ -233,19 +233,21 @@ class ElectrodeArray(object):
         A single epiretinal electrode called 'A1', with radius 100um, sitting
         at retinal location (0, 0), 10um away from the retina:
         >>> from pulse2percept import electrode2currentmap as e2cm
-        >>> implant = e2cm.ElectrodeArray('epiretinal', 100, 0, 0, 10, 'A1')
+        >>> implant1 = e2cm.ElectrodeArray('epiretinal', 100, 0, 0, 10, 'A1')
 
         An array with two electrodes of size 100um, one sitting at
         (-100, -100), the other sitting at (0, 0), with 0 distance from the
         retina, of type 'subretinal':
-        >>> implant = e2cm.ElectrodeArray('subretinal', [100, 100], [-100, 0],
-                                          [-100, 0], [0, 0])
-
-        Get access to the second electrode in the array:
-        >>> my_electrode = implant[1]
+        >>> implant2 = e2cm.ElectrodeArray('subretinal', [100, 100], [-100, 0],
+        ...                                [-100, 0], [0, 0])
 
         Get access to the electrode with name 'A1' in the array:
-        >>> my_electrode = implant['A1']
+        >>> my_electrode = implant1['A1']
+
+        Get access to the second electrode in the array:
+        >>> my_electrode = implant2[1]
+
+
 
         """
         # Make it so the constructor can accept either floats, lists, or

--- a/pulse2percept/tests/test_effectivecurrent2brightness.py
+++ b/pulse2percept/tests/test_effectivecurrent2brightness.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 import pulse2percept.electrode2currentmap as e2cm
 import pulse2percept.effectivecurrent2brightness as ec2b
 from pulse2percept.utils import TimeSeries
@@ -18,14 +19,17 @@ def test_pulse2percept():
     fl_dummy = 10.2
     engine = 'serial'
     dojit = False
-    npt.assert_raises(TypeError, ec2b.pulse2percept, pt, implant, retina,
-                      fl_dummy, fl_dummy, fl_dummy, True, engine, dojit)
-    npt.assert_raises(TypeError, ec2b.pulse2percept, pt, electrode,
-                      tm, retina, fl_dummy, fl_dummy, fl_dummy, True,
-                      engine, dojit)
-    npt.assert_raises(TypeError, ec2b.pulse2percept, pt, implant,
-                      retina, retina, fl_dummy, fl_dummy, fl_dummy,
-                      True, engine, dojit)
+    with pytest.raises(TypeError) as e_info:
+        ec2b.pulse2percept(pt, implant, retina,
+                           fl_dummy, fl_dummy, fl_dummy, True, engine, dojit)
+    with pytest.raises(TypeError) as e_info:
+        ec2b.pulse2percept(pt, electrode,
+                           tm, retina, fl_dummy, fl_dummy, fl_dummy, True,
+                           engine, dojit)
+    with pytest.raises(TypeError) as e_info:
+        ec2b.pulse2percept(pt, implant,
+                           retina, retina, fl_dummy, fl_dummy, fl_dummy,
+                           True, engine, dojit)
 
     # Smoke testing
     ec2b.pulse2percept(pt, implant, tm, retina, engine=engine, dojit=dojit)
@@ -152,12 +156,15 @@ def test_parse_pulse_trains():
     # Test 1
     # ------
     # Specify wrong number of pulse trains
-    npt.assert_raises(ValueError, ec2b.parse_pulse_trains, pt_nonzero, argus)
-    npt.assert_raises(ValueError, ec2b.parse_pulse_trains, [pt_nonzero], argus)
-    npt.assert_raises(ValueError, ec2b.parse_pulse_trains,
-                      [pt_nonzero] * (argus.num_electrodes - 1), argus)
-    npt.assert_raises(ValueError, ec2b.parse_pulse_trains, [pt_nonzero] * 2,
-                      simple)
+    with pytest.raises(ValueError) as e_info:
+        ec2b.parse_pulse_trains(pt_nonzero, argus)
+    with pytest.raises(ValueError) as e_info:
+        ec2b.parse_pulse_trains([pt_nonzero], argus)
+    with pytest.raises(ValueError) as e_info:
+        ec2b.parse_pulse_trains([pt_nonzero] * (argus.num_electrodes - 1),
+                                argus)
+    with pytest.raises(ValueError) as e_info:
+        ec2b.parse_pulse_trains([pt_nonzero] * 2, simple)
 
     # Test 2
     # ------

--- a/pulse2percept/tests/test_electrode2currentmap.py
+++ b/pulse2percept/tests/test_electrode2currentmap.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 import pulse2percept.electrode2currentmap as e2cm
 
@@ -39,8 +40,8 @@ def test_ElectrodeArray():
         npt.assert_equal(arr.electrodes[0].etype, 'epiretinal')
 
     # However, all input arguments must have the same number of elements
-    npt.assert_raises(AssertionError, e2cm.ElectrodeArray, 'epiretinal', [0],
-                      [1, 2], [3, 4, 5], [6])
+    with pytest.raises(AssertionError) as e_info:
+        e2cm.ElectrodeArray('epiretinal', [0], [1, 2], [3, 4, 5], [6])
 
     # Make sure electrodes can be addressed by index
     vals = range(5)
@@ -94,7 +95,8 @@ def test_ArgusI():
                     npt.assert_almost_equal(x_center, x)
 
     # `h` must have the right dimensions
-    npt.assert_raises(ValueError, e2cm.ArgusI, -100, 10, h=np.zeros(5))
+    with pytest.raises(ValueError) as e_info:
+        e2cm.ArgusI(-100, 10, h=np.zeros(5))
 
     # Indexing must work for both integers and electrode names
     argus = e2cm.ArgusI()
@@ -151,7 +153,8 @@ def test_ArgusII():
                     npt.assert_almost_equal(x_center, x)
 
     # `h` must have the right dimensions
-    npt.assert_raises(ValueError, e2cm.ArgusII, -100, 10, h=np.zeros(5))
+    with pytest.raises(ValueError) as e_info:
+        e2cm.ArgusII(-100, 10, h=np.zeros(5))
 
     # Indexing must work for both integers and electrode names
     argus = e2cm.ArgusII()


### PR DESCRIPTION
... and a bug. 

This PR removes the nose dependency, by using pytest's assertion tests.

I also introduced doc-testing, which runs the examples from the docstrings (that's the `--doctest-modules` flag in the call to pytest in `.travis.yml`). 

This is where I ran into a bug in this doctest: 

https://github.com/uwescience/pulse2percept/pull/53/files#diff-20cba84535ecdc25045594cfd16b27c2R283

I think this comes from the fact that when you do the list comprehension here: 

https://github.com/uwescience/pulse2percept/pull/53/files#diff-20cba84535ecdc25045594cfd16b27c2R310

It calls the new `__getitem__` function with the `item` input set to `None`, triggering this block: 

https://github.com/uwescience/pulse2percept/pull/53/files#diff-73ece439b09983acb02125eccea35389R289

I am not sure how to fix this one. Maybe by setting a default value for the `item` input, so that when list-comprehension happens it triggers that case (I assume that would fix this, but don't know this for a fact). 